### PR TITLE
disable extra-semicolon not allowed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,5 +8,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 6
   },
-  rules: {}
+  rules: {
+    "semi": 0
+  }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line -->
#### Description of the change

This should be discutable. But with 5+ years of code behind me, i always used the semi-colon to end my lines. In fact, in C++ and C, semicolon are mandatory. I know javascript don't bother of the semicolon, but i think it's a good way to upgrade your code constancy.

CLOSES #ISSUENO <!-- Please create a issue before a pull request for better collaboration 💪 -->

#### Checklist\*

**Please make sure you have done the following:**

- [x] 😄 I've read [CONTRIBUTING.md](contributing) and my PR is up to standards.
- [x] 🎨 The changes in this PR meet the design plan.
- [x] 🐛 I've tested my PR's source changes for any bugs/render issues.
- [x] 🧪 I've worked through build failures and tests are passing.
- [x] 📄 I've updated the necessary documentation changes.

#### Notes

<!--
  Add something you wanna tell the reviewers like:
    - Ask the reviewers questions you need answered to ship the PR if any.
    - If your PR is large, use a table to highlight changes with high user impact.
    - Discuss about failing CI if any.
    - Discuss about version issues if any.
    - Something else the reviewers should know to consider the overall user experience of the PR?
-->

<!-- All required info has \* in the title -->

[contributing]: https://github.com/web3community/DEV-NFT/blob/main/CONTRIBUTING.md
